### PR TITLE
Centrar mapa em abrantes

### DIFF
--- a/app/src/main/java/com/example/raullino/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/example/raullino/ui/map/MapFragment.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
@@ -44,6 +45,29 @@ class MapFragment : Fragment() {
             Manifest.permission.ACCESS_COARSE_LOCATION
         )
         requestPermissionsIfNecessary(permissions)
+
+        // Add touch listener to limit map view area
+        val initialLocation = GeoPoint(39.4666700, -8.2000000)
+        val maxLat = initialLocation.latitude + 0.01
+        val minLat = initialLocation.latitude - 0.01
+        val maxLon = initialLocation.longitude + 0.01
+        val minLon = initialLocation.longitude - 0.01
+        val mapTouchListener = View.OnTouchListener {_, event ->
+            if (event.action == MotionEvent.ACTION_UP) {
+                val center = mapView.mapCenter
+                val lat = center.latitude
+                val lon = center.longitude
+                if (lat > maxLat || lat < minLat || lon > maxLon || lon < minLon) {
+                    mapView.controller.animateTo(GeoPoint(39.4666700, -8.2000000))
+                    return@OnTouchListener true
+                }
+            }
+            false
+        }
+        mapView.setOnTouchListener(mapTouchListener)
+
+
+
 
         return view
     }

--- a/app/src/main/res/layout/fragment_biography.xml
+++ b/app/src/main/res/layout/fragment_biography.xml
@@ -5,11 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.biography.BiographyFragment">
-
-    <include layout="@layout/header_menu"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
-
+    
     <TextView
         android:id="@+id/text_biography"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -6,15 +6,6 @@
     android:layout_height="match_parent"
     tools:context=".ui.home.HomeFragment">
 
-    <include
-        android:id="@+id/include"
-        layout="@layout/header_menu"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
     <TextView
         android:id="@+id/text_home"
         android:layout_width="match_parent"


### PR DESCRIPTION
Sempre que o mapa é desviado da zona de Abrantes, este volta a centrar-se automaticamente em Abrantes, impedindo o foco fora desta localidade.

